### PR TITLE
Initial ICMP support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ path = "src/icmpd/main.rs"
 [dependencies]
 netutils = { git = "https://github.com/redox-os/netutils.git" }
 rand = "0.3"
-redox_event = { path = "../event" }
+redox_event = { git = "https://github.com/redox-os/event.git" }
 redox_syscall = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,12 @@ path = "src/tcpd/main.rs"
 name = "udpd"
 path = "src/udpd/main.rs"
 
+[[bin]]
+name = "icmpd"
+path = "src/icmpd/main.rs"
+
 [dependencies]
 netutils = { git = "https://github.com/redox-os/netutils.git" }
 rand = "0.3"
-redox_event = "0.1"
+redox_event = { path = "../event" }
 redox_syscall = "0.1"

--- a/src/icmpd/error.rs
+++ b/src/icmpd/error.rs
@@ -1,8 +1,8 @@
-use std::result;
-use std::fmt;
-use syscall::error::Error as SyscallError;
-use std::io::Error as IOError;
 use std::convert;
+use std::fmt;
+use std::io::Error as IOError;
+use std::result;
+use syscall::error::Error as SyscallError;
 
 pub enum PacketError {
     NotEnoughData,

--- a/src/icmpd/error.rs
+++ b/src/icmpd/error.rs
@@ -1,0 +1,80 @@
+use std::result;
+use std::fmt;
+use syscall::error::Error as SyscallError;
+use std::io::Error as IOError;
+use std::convert;
+
+pub enum ParsingError {
+    NotEnoughData,
+    IncorrectChecksum,
+}
+
+enum ErrorType {
+    Syscall(SyscallError),
+    IOError(IOError),
+    ParsingError(ParsingError),
+}
+
+pub struct Error {
+    error_type: ErrorType,
+    descr: String,
+}
+
+impl Error {
+    pub fn from_parsing_error<S: Into<String>>(parsing_error: ParsingError, descr: S) -> Error {
+        Error {
+            error_type: ErrorType::ParsingError(parsing_error),
+            descr: descr.into(),
+        }
+    }
+    pub fn from_syscall_error<S: Into<String>>(syscall_error: SyscallError, descr: S) -> Error {
+        Error {
+            error_type: ErrorType::Syscall(syscall_error),
+            descr: descr.into(),
+        }
+    }
+
+    pub fn from_io_error<S: Into<String>>(io_error: IOError, descr: S) -> Error {
+        Error {
+            error_type: ErrorType::IOError(io_error),
+            descr: descr.into(),
+        }
+    }
+}
+
+impl fmt::Display for ParsingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+        write!(f, "{}", match *self {
+            ParsingError::NotEnoughData => "not enough data",
+            ParsingError::IncorrectChecksum => "checksum error",
+        })
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
+        match self.error_type {
+            ErrorType::Syscall(ref syscall_error) => {
+                write!(f, "{} : syscall error: {}", self.descr, syscall_error)
+            }
+            ErrorType::IOError(ref io_error) => {
+                write!(f, "{} : io error : {}", self.descr, io_error)
+            }
+            ErrorType::ParsingError(ref parsign_error) => {
+                write!(f,
+                       "{} : packet parsing error : {}",
+                       self.descr,
+                       parsign_error)
+            }
+        }
+    }
+}
+
+impl convert::From<IOError> for Error {
+    fn from(e: IOError) -> Self {
+        Error::from_io_error(e, "")
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
+pub type ParsingResult<T> = result::Result<T, ParsingError>;

--- a/src/icmpd/main.rs
+++ b/src/icmpd/main.rs
@@ -2,114 +2,58 @@ extern crate event;
 extern crate syscall;
 extern crate netutils;
 
-use error::{Result, Error, ParsingError};
+use error::{Result, Error};
 use event::EventQueue;
-use netutils::{Ipv4, Ipv4Header, Checksum, n16};
-use packet::{Packet, MutPacket};
+use scheme::Icmpd;
+use std::cell::RefCell;
 use std::fs::File;
-use std::io::{Read, Write};
 use std::os::unix::io::{RawFd, FromRawFd};
 use std::process;
-use std::mem;
+use std::rc::Rc;
 
 mod error;
 mod packet;
-
-const MAX_PACKET_SIZE: usize = 2048;
-
-fn do_echo_response(in_ip_packet: &Ipv4,
-                    in_icmp_packet: &Packet,
-                    icmp_file: &mut File)
-                    -> Result<()> {
-    let mut ip_data = vec![0; in_icmp_packet.get_total_data_size()];
-    {
-        let mut out_icmp_packet =
-            MutPacket::from_bytes(&mut ip_data)
-                .map_err(|e| Error::from_parsing_error(e, "can't parse empty icmp header"))?;
-        out_icmp_packet.set_echo_response();
-        {
-            let payload = out_icmp_packet.get_payload();
-            let in_payload = in_icmp_packet.get_payload();
-            if payload.len() != in_payload.len() {
-                return Err(Error::from_parsing_error(ParsingError::NotEnoughData,
-                                                     " can't copy icmp payload to echo response"));
-            }
-            //WARNING: copy_from_slice can panic if the slices' lengths are different
-            payload.copy_from_slice(in_icmp_packet.get_payload());
-        }
-        out_icmp_packet.compute_checksum();
-    }
-    let out_ip_packet = Ipv4 {
-        header: Ipv4Header {
-            ver_hlen: 0x45,
-            services: 0,
-            len: n16::new((ip_data.len() + mem::size_of::<Ipv4Header>()) as u16),
-            id: n16::new(0),
-            flags_fragment: n16::new(0),
-            ttl: in_ip_packet.header.ttl,
-            proto: 1,
-            checksum: Checksum { data: 0 },
-            src: in_ip_packet.header.dst,
-            dst: in_ip_packet.header.src,
-        },
-        options: Vec::new(),
-        data: ip_data,
-    };
-    icmp_file
-        .write(&out_ip_packet.to_bytes())
-        .map_err(|e| Error::from_io_error(e, " can't send an echo response packet"))
-        .map(|_| ())
-}
-
-fn on_icmp_packet(icmp_file: &mut File) -> Result<Option<()>> {
-    let mut packet_buffer = [0; MAX_PACKET_SIZE];
-    loop {
-        let bytes_readed =
-            icmp_file
-                .read(&mut packet_buffer)
-                .map_err(|e| Error::from_io_error(e, "failed to read a packet from ip:1"))?;
-        if bytes_readed == 0 {
-            break;
-        }
-        let ip_packet = Ipv4::from_bytes(&packet_buffer[..bytes_readed])
-            .ok_or(Error::from_parsing_error(ParsingError::NotEnoughData,
-                                             "failed to parse ip header"))?;
-        let icmp_packet =
-            Packet::from_bytes(&ip_packet.data)
-                .map_err(|e| Error::from_parsing_error(e, "failed to parse ICMP packet"))?;
-
-        if icmp_packet.is_echo_request() {
-            do_echo_response(&ip_packet, &icmp_packet, icmp_file)?;
-        }
-    }
-    Ok(None)
-}
+mod scheme;
 
 fn run() -> Result<()> {
     use syscall::flag::*;
 
     let icmp_fd = syscall::open("ip:1", O_RDWR | O_NONBLOCK)
-        .map_err(|e| Error::from_syscall_error(e, "failed to open ip:1"))?;
+        .map_err(|e| Error::from_syscall_error(e, "failed to open ip:1"))? as
+                  RawFd;
+
+    let scheme_fd = syscall::open(":icmp", O_RDWR | O_CREAT | O_NONBLOCK)
+        .map_err(|e| Error::from_syscall_error(e, "failed to open :icmp"))? as
+                    RawFd;
 
     if unsafe { syscall::clone(0).unwrap() } != 0 {
         return Ok(());
     }
 
+    let icmpd = Rc::new(RefCell::new(Icmpd::new(unsafe { File::from_raw_fd(icmp_fd) },
+                                                unsafe { File::from_raw_fd(scheme_fd) })));
+
     let mut event_queue =
         EventQueue::<(), Error>::new()
             .map_err(|e| Error::from_io_error(e, "failed to create event queue"))?;
-    let mut icmp_file = unsafe { File::from_raw_fd(icmp_fd as RawFd) };
+
+    let icmpd_ = icmpd.clone();
+
     event_queue
-        .add(icmp_fd as RawFd,
-             move |_fd| -> Result<Option<()>> { on_icmp_packet(&mut icmp_file) })
+        .add(icmp_fd, move |_fd| icmpd_.borrow_mut().on_icmp_packet())
         .map_err(|e| Error::from_io_error(e, "failed to listen to events on ip:1"))?;
+
+    event_queue
+        .add(scheme_fd, move |_fd| icmpd.borrow_mut().on_scheme_event())
+        .map_err(|e| Error::from_io_error(e, "failed to listen to events on icmp"))?;
+
     event_queue.run()
 }
 
 fn main() {
-    match run() {
-        Err(err) => println!("icmpd: {}", err),
-        _ => {}
+    if let Err(err) = run() {
+        println!("icmpd: {}", err);
+        process::exit(1);
     }
     process::exit(0);
 }

--- a/src/icmpd/main.rs
+++ b/src/icmpd/main.rs
@@ -18,6 +18,10 @@ mod scheme;
 fn run() -> Result<()> {
     use syscall::flag::*;
 
+    if unsafe { syscall::clone(0).unwrap() } != 0 {
+        return Ok(());
+    }
+
     let icmp_fd = syscall::open("ip:1", O_RDWR | O_NONBLOCK)
         .map_err(|e| Error::from_syscall_error(e, "failed to open ip:1"))? as
                   RawFd;
@@ -26,9 +30,6 @@ fn run() -> Result<()> {
         .map_err(|e| Error::from_syscall_error(e, "failed to open :icmp"))? as
                     RawFd;
 
-    if unsafe { syscall::clone(0).unwrap() } != 0 {
-        return Ok(());
-    }
 
     let icmpd = Rc::new(RefCell::new(Icmpd::new(unsafe { File::from_raw_fd(icmp_fd) },
                                                 unsafe { File::from_raw_fd(scheme_fd) })));

--- a/src/icmpd/main.rs
+++ b/src/icmpd/main.rs
@@ -1,0 +1,115 @@
+extern crate event;
+extern crate syscall;
+extern crate netutils;
+
+use error::{Result, Error, ParsingError};
+use event::EventQueue;
+use netutils::{Ipv4, Ipv4Header, Checksum, n16};
+use packet::{Packet, MutPacket};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::os::unix::io::{RawFd, FromRawFd};
+use std::process;
+use std::mem;
+
+mod error;
+mod packet;
+
+const MAX_PACKET_SIZE: usize = 2048;
+
+fn do_echo_response(in_ip_packet: &Ipv4,
+                    in_icmp_packet: &Packet,
+                    icmp_file: &mut File)
+                    -> Result<()> {
+    let mut ip_data = vec![0; in_icmp_packet.get_total_data_size()];
+    {
+        let mut out_icmp_packet =
+            MutPacket::from_bytes(&mut ip_data)
+                .map_err(|e| Error::from_parsing_error(e, "can't parse empty icmp header"))?;
+        out_icmp_packet.set_echo_response();
+        {
+            let payload = out_icmp_packet.get_payload();
+            let in_payload = in_icmp_packet.get_payload();
+            if payload.len() != in_payload.len() {
+                return Err(Error::from_parsing_error(ParsingError::NotEnoughData,
+                                                     " can't copy icmp payload to echo response"));
+            }
+            //WARNING: copy_from_slice can panic if the slices' lengths are different
+            payload.copy_from_slice(in_icmp_packet.get_payload());
+        }
+        out_icmp_packet.compute_checksum();
+    }
+    let out_ip_packet = Ipv4 {
+        header: Ipv4Header {
+            ver_hlen: 0x45,
+            services: 0,
+            len: n16::new((ip_data.len() + mem::size_of::<Ipv4Header>()) as u16),
+            id: n16::new(0),
+            flags_fragment: n16::new(0),
+            ttl: in_ip_packet.header.ttl,
+            proto: 1,
+            checksum: Checksum { data: 0 },
+            src: in_ip_packet.header.dst,
+            dst: in_ip_packet.header.src,
+        },
+        options: Vec::new(),
+        data: ip_data,
+    };
+    icmp_file
+        .write(&out_ip_packet.to_bytes())
+        .map_err(|e| Error::from_io_error(e, " can't send an echo response packet"))
+        .map(|_| ())
+}
+
+fn on_icmp_packet(icmp_file: &mut File) -> Result<Option<()>> {
+    let mut packet_buffer = [0; MAX_PACKET_SIZE];
+    loop {
+        let bytes_readed =
+            icmp_file
+                .read(&mut packet_buffer)
+                .map_err(|e| Error::from_io_error(e, "failed to read a packet from ip:1"))?;
+        if bytes_readed == 0 {
+            break;
+        }
+        let ip_packet = Ipv4::from_bytes(&packet_buffer[..bytes_readed])
+            .ok_or(Error::from_parsing_error(ParsingError::NotEnoughData,
+                                             "failed to parse ip header"))?;
+        let icmp_packet =
+            Packet::from_bytes(&ip_packet.data)
+                .map_err(|e| Error::from_parsing_error(e, "failed to parse ICMP packet"))?;
+
+        if icmp_packet.is_echo_request() {
+            do_echo_response(&ip_packet, &icmp_packet, icmp_file)?;
+        }
+    }
+    Ok(None)
+}
+
+fn run() -> Result<()> {
+    use syscall::flag::*;
+
+    let icmp_fd = syscall::open("ip:1", O_RDWR | O_NONBLOCK)
+        .map_err(|e| Error::from_syscall_error(e, "failed to open ip:1"))?;
+
+    if unsafe { syscall::clone(0).unwrap() } != 0 {
+        return Ok(());
+    }
+
+    let mut event_queue =
+        EventQueue::<(), Error>::new()
+            .map_err(|e| Error::from_io_error(e, "failed to create event queue"))?;
+    let mut icmp_file = unsafe { File::from_raw_fd(icmp_fd as RawFd) };
+    event_queue
+        .add(icmp_fd as RawFd,
+             move |_fd| -> Result<Option<()>> { on_icmp_packet(&mut icmp_file) })
+        .map_err(|e| Error::from_io_error(e, "failed to listen to events on ip:1"))?;
+    event_queue.run()
+}
+
+fn main() {
+    match run() {
+        Err(err) => println!("icmpd: {}", err),
+        _ => {}
+    }
+    process::exit(0);
+}

--- a/src/icmpd/packet.rs
+++ b/src/icmpd/packet.rs
@@ -1,0 +1,100 @@
+use error::{ParsingResult, ParsingError};
+use netutils::Checksum;
+use std::mem;
+
+#[repr(packed)]
+pub struct Header {
+    icmp_type: u8,
+    icmp_code: u8,
+    crc: u16,
+}
+
+pub struct Packet<'a> {
+    header: &'a Header,
+    payload: &'a [u8],
+}
+
+pub struct MutPacket<'a> {
+    header: &'a mut Header,
+    payload: &'a mut [u8],
+}
+
+impl<'a> Packet<'a> {
+    pub fn from_bytes<'b>(bytes: &'b [u8]) -> ParsingResult<Packet<'a>>
+        where 'b: 'a
+    {
+        if bytes.len() < mem::size_of::<Header>() {
+            Err(ParsingError::NotEnoughData)
+        } else {
+            let (header_bytes, payload_bytes) = bytes.split_at(mem::size_of::<Header>());
+            let packet = Packet {
+                header: unsafe { mem::transmute(header_bytes.as_ptr()) },
+                payload: payload_bytes,
+            };
+            if packet.is_checksum_ok() {
+                Ok(packet)
+            } else {
+                Err(ParsingError::IncorrectChecksum)
+            }
+        }
+    }
+
+    fn is_checksum_ok(&self) -> bool {
+        let header_ptr = self.header as *const Header as usize;
+        let total_size = self.get_total_data_size();
+        let mut crc = unsafe { Checksum::sum(header_ptr, total_size) };
+        crc -= u16::from_be(self.header.crc) as usize;
+        let crc = Checksum::compile(crc);
+        crc == u16::from_be(self.header.crc)
+    }
+
+    pub fn is_echo_request(&self) -> bool {
+        self.header.icmp_type == ECHO_REQUEST_TYPE && self.header.icmp_code == ECHO_REQUEST_CODE
+    }
+
+    pub fn get_payload(&self) -> &[u8] {
+        self.payload
+    }
+
+    pub fn get_total_data_size(&self) -> usize {
+        mem::size_of::<Header>() + self.payload.len()
+    }
+}
+
+impl<'a> MutPacket<'a> {
+    pub fn from_bytes<'b>(bytes: &'b mut [u8]) -> ParsingResult<MutPacket<'a>>
+        where 'b: 'a
+    {
+        if bytes.len() < mem::size_of::<Header>() {
+            Err(ParsingError::NotEnoughData)
+        } else {
+            let (header_bytes, payload_bytes) = bytes.split_at_mut(mem::size_of::<Header>());
+            Ok(MutPacket {
+                   header: unsafe { mem::transmute(header_bytes.as_ptr()) },
+                   payload: payload_bytes,
+               })
+        }
+    }
+
+    pub fn set_echo_response(&mut self) {
+        self.header.icmp_type = ECHO_RESPONSE_TYPE;
+        self.header.icmp_code = ECHO_RESPONSE_CODE;
+    }
+
+    pub fn compute_checksum(&mut self) {
+        self.header.crc = 0;
+        let header_ptr = self.header as *mut Header as usize;
+        let total_size = mem::size_of::<Header>() + self.payload.len();
+        let crc = Checksum::compile(unsafe { Checksum::sum(header_ptr, total_size) });
+        self.header.crc = crc
+    }
+
+    pub fn get_payload(&mut self) -> &mut [u8] {
+        self.payload
+    }
+}
+
+const ECHO_REQUEST_TYPE: u8 = 8;
+const ECHO_REQUEST_CODE: u8 = 0;
+const ECHO_RESPONSE_TYPE: u8 = 0;
+const ECHO_RESPONSE_CODE: u8 = 0;

--- a/src/icmpd/packet.rs
+++ b/src/icmpd/packet.rs
@@ -13,7 +13,7 @@ pub struct Header {
 #[repr(packed)]
 pub struct EchoHeader {
     id: u16,
-    seq: u16,
+    //Seq is set by the caller
 }
 
 pub enum SubHeader<'a> {
@@ -43,19 +43,14 @@ pub enum PacketKind {
 }
 
 impl EchoHeader {
-    pub fn new(id: u16, seq: u16) -> EchoHeader {
+    pub fn new(id: u16) -> EchoHeader {
         EchoHeader {
             id: id.to_be(),
-            seq: seq.to_be(),
         }
     }
 
     pub fn get_id(&self) -> u16 {
         u16::from_be(self.id)
-    }
-
-    pub fn get_seq(&self) -> u16 {
-        u16::from_be(self.seq)
     }
 }
 
@@ -193,7 +188,7 @@ impl<'a> MutPacket<'a> {
     pub fn compute_checksum(&mut self) {
         self.header.crc = 0;
         let header_ptr = self.header as *mut Header as usize;
-        let total_size = mem::size_of::<Header>() + self.payload.len();
+        let total_size = Self::get_total_header_size(&self.subheader) + self.payload.len();
         let crc = Checksum::compile(unsafe { Checksum::sum(header_ptr, total_size) });
         self.header.crc = crc
     }

--- a/src/icmpd/scheme.rs
+++ b/src/icmpd/scheme.rs
@@ -1,0 +1,288 @@
+use error::{Result, Error, ParsingError};
+use netutils::{Ipv4, Ipv4Header, Checksum, n16};
+use netutils;
+use packet::{Header, Packet, MutPacket, PacketKind};
+use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::mem;
+use std::net::Ipv4Addr;
+use syscall::SchemeMut;
+use syscall;
+
+//Some reasonable limits, 65k is a waste of memory
+const MAX_PACKET_SIZE: usize = 2048;
+const MAX_ICMP_PAYLOAD_SIZE: usize = 2000;
+
+enum HandleType {
+    Echo,
+}
+
+struct Handle {
+    handle_type: HandleType,
+    events: usize,
+    flags: usize,
+    ip_addr: Ipv4Addr,
+    payload_queue: VecDeque<Vec<u8>>,
+}
+
+impl Handle {
+    pub fn new(handle_type: HandleType, ip_addr: Ipv4Addr, flags: usize) -> Handle {
+        Handle {
+            handle_type,
+            events: 0,
+            ip_addr,
+            payload_queue: VecDeque::new(),
+            flags,
+        }
+    }
+}
+
+pub struct Icmpd {
+    icmp_file: File,
+    scheme_file: File,
+    next_fd: usize,
+    echo_ips: BTreeMap<Ipv4Addr, HashSet<usize>>,
+    handles: BTreeMap<usize, Handle>,
+}
+
+impl Icmpd {
+    pub fn new(icmp_file: File, scheme_file: File) -> Icmpd {
+        Icmpd {
+            icmp_file,
+            scheme_file,
+            next_fd: 0,
+            echo_ips: BTreeMap::new(),
+            handles: BTreeMap::new(),
+        }
+    }
+
+    pub fn on_scheme_event(&mut self) -> Result<Option<()>> {
+        loop {
+            let mut packet = syscall::Packet::default();
+            if self.scheme_file.read(&mut packet)? == 0 {
+                break;
+            }
+            self.handle(&mut packet);
+        }
+        Ok(None)
+    }
+
+    pub fn on_icmp_packet(&mut self) -> Result<Option<()>> {
+        let mut packet_buffer = [0; MAX_PACKET_SIZE];
+        loop {
+            let bytes_readed =
+                self.icmp_file
+                    .read(&mut packet_buffer)
+                    .map_err(|e| Error::from_io_error(e, "failed to read a packet from ip:1"))?;
+            if bytes_readed == 0 {
+                break;
+            }
+            let ip_packet = Ipv4::from_bytes(&packet_buffer[..bytes_readed])
+                .ok_or(Error::from_parsing_error(ParsingError::NotEnoughData,
+                                                 "failed to parse ip header"))?;
+            let icmp_packet =
+                Packet::from_bytes(&ip_packet.data)
+                    .map_err(|e| Error::from_parsing_error(e, "failed to parse ICMP packet"))?;
+
+            match icmp_packet.get_kind() {
+                PacketKind::EchoRequest => self.on_echo_request(&ip_packet, &icmp_packet)?,
+                PacketKind::EchoResponse => self.on_echo_response(&ip_packet, &icmp_packet)?,
+                _ => (),
+            }
+        }
+        Ok(None)
+    }
+
+    fn on_echo_request(&mut self, ip_packet: &Ipv4, icmp_packet: &Packet) -> Result<()> {
+        let echo_response = produce_icmp_packet(Ipv4Addr::from(ip_packet.header.src.bytes),
+                                                PacketKind::EchoResponse,
+                                                icmp_packet.get_payload())?;
+        self.icmp_file
+            .write(&echo_response)
+            .map_err(|e| Error::from_io_error(e, " can't send an echo response packet"))
+            .map(|_| ())
+    }
+
+    fn on_echo_response(&mut self, ip_packet: &Ipv4, icmp_packet: &Packet) -> Result<()> {
+        if let Some(fd_set) = self.echo_ips
+               .get_mut(&Ipv4Addr::from(ip_packet.header.src.bytes)) {
+            for fd in fd_set.iter() {
+                if let Some(handle) = self.handles.get_mut(fd) {
+                    handle
+                        .payload_queue
+                        .push_back(Vec::from(icmp_packet.get_payload()));
+                    post_fevent(&mut self.scheme_file,
+                                *fd,
+                                syscall::EVENT_READ,
+                                icmp_packet.get_payload().len())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn open_echo(&mut self, ip_addr: Ipv4Addr, flags: usize) -> syscall::Result<usize> {
+        let fd = self.next_fd;
+        self.next_fd += 1;
+        let handle = Handle::new(HandleType::Echo, ip_addr, flags);
+        self.handles.insert(fd, handle);
+        self.echo_ips
+            .entry(ip_addr)
+            .or_insert_with(|| HashSet::new())
+            .insert(fd);
+        Ok(fd)
+    }
+
+    fn read_echo(handle: &mut Handle, buf: &mut [u8]) -> syscall::Result<usize> {
+        if let Some(payload) = handle.payload_queue.pop_front() {
+            //TODO replace with a proper memcpy
+            let mut i = 0;
+            while i < buf.len() && i < payload.len() {
+                buf[i] = payload[i];
+                i += 1;
+            }
+            Ok(i)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+impl SchemeMut for Icmpd {
+    fn open(&mut self, url: &[u8], flags: usize, _uid: u32, _gid: u32) -> syscall::Result<usize> {
+        use std::str;
+        use std::str::FromStr;
+
+        // if uid != 0 {
+        //     return Err(syscall::Error::new(syscall::EACCES));
+        // }
+
+        let path = str::from_utf8(url)
+            .or(Err(syscall::Error::new(syscall::EINVAL)))?;
+        let mut parts = path.split("/");
+        let method = parts.next().ok_or(syscall::Error::new(syscall::EINVAL))?;
+        match method {
+            "echo" => {
+                let addr = parts.next().ok_or(syscall::Error::new(syscall::EINVAL))?;
+                let addr = Ipv4Addr::from_str(&addr)
+                    .map_err(|_| syscall::Error::new(syscall::EINVAL))?;
+                self.open_echo(addr, flags)
+            }
+            _ => Err(syscall::Error::new(syscall::EINVAL)),
+        }
+    }
+
+    fn close(&mut self, fd: usize) -> syscall::Result<usize> {
+        let (ip, ip_set) = {
+            let handle = self.handles
+                .get_mut(&fd)
+                .ok_or(syscall::Error::new(syscall::EBADF))?;
+            match handle.handle_type {
+                HandleType::Echo => (handle.ip_addr, &mut self.echo_ips),
+            }
+        };
+        self.handles.remove(&fd);
+        let remove_ip = if let Some(fd_set) = ip_set.get_mut(&ip) {
+            fd_set.remove(&fd);
+            fd_set.is_empty()
+        } else {
+            false
+        };
+
+        if remove_ip {
+            ip_set.remove(&ip);
+        }
+
+        Ok(0)
+    }
+
+    fn write(&mut self, fd: usize, buf: &[u8]) -> syscall::Result<usize> {
+        if buf.len() > MAX_ICMP_PAYLOAD_SIZE {
+            return Err(syscall::Error::new(syscall::EMSGSIZE));
+        }
+        let handle = self.handles
+            .get_mut(&fd)
+            .ok_or(syscall::Error::new(syscall::EBADF))?;
+        match handle.handle_type {
+            HandleType::Echo => {
+                let echo_request =
+                    produce_icmp_packet(handle.ip_addr, PacketKind::EchoRequest, buf)
+                        .map_err(|_| syscall::Error::new(syscall::EPROTO))?;
+                self.icmp_file
+                    .write(&echo_request)
+                    .map_err(|_| syscall::Error::new(syscall::EPROTO))
+            }
+        }
+    }
+
+    fn read(&mut self, fd: usize, buf: &mut [u8]) -> syscall::Result<usize> {
+        let handle = self.handles
+            .get_mut(&fd)
+            .ok_or(syscall::Error::new(syscall::EBADF))?;
+        match handle.handle_type {
+            HandleType::Echo => Icmpd::read_echo(handle, buf),
+        }
+    }
+
+    fn fevent(&mut self, fd: usize, events: usize) -> syscall::Result<usize> {
+        let handle = self.handles
+            .get_mut(&fd)
+            .ok_or(syscall::Error::new(syscall::EBADF))?;
+        handle.events = events;
+        Ok(fd)
+    }
+}
+
+fn produce_icmp_packet(to_ip: Ipv4Addr, kind: PacketKind, payload: &[u8]) -> Result<Vec<u8>> {
+    let mut ip_data = vec![0; mem::size_of::<Header>() + payload.len()];
+    {
+        let mut out_icmp_packet =
+            MutPacket::from_bytes(&mut ip_data)
+                .map_err(|e| Error::from_parsing_error(e, "can't parse empty icmp header"))?;
+        out_icmp_packet.set_kind(kind);
+        {
+            let out_payload = out_icmp_packet.get_payload();
+            if out_payload.len() != payload.len() {
+                return Err(Error::from_parsing_error(ParsingError::NotEnoughData,
+                                                     " can't copy icmp payload to echo response"));
+            }
+            //WARNING: copy_from_slice can panic if the slices' lengths are different
+            out_payload.copy_from_slice(payload);
+        }
+        out_icmp_packet.compute_checksum();
+    }
+    let out_ip_packet = Ipv4 {
+        header: Ipv4Header {
+            ver_hlen: 0x45,
+            services: 0,
+            len: n16::new((ip_data.len() + mem::size_of::<Ipv4Header>()) as u16),
+            id: n16::new(0),
+            flags_fragment: n16::new(0),
+            ttl: 64,
+            proto: 1,
+            checksum: Checksum { data: 0 },
+            src: netutils::Ipv4Addr::NULL,
+            dst: netutils::Ipv4Addr { bytes: to_ip.octets() },
+        },
+        options: Vec::new(),
+        data: ip_data,
+    };
+    Ok(out_ip_packet.to_bytes())
+}
+
+fn post_fevent(scheme_file: &mut File, fd: usize, event: usize, data_len: usize) -> Result<()> {
+    scheme_file
+        .write(&syscall::Packet {
+                   id: 0,
+                   pid: 0,
+                   uid: 0,
+                   gid: 0,
+                   a: syscall::number::SYS_FEVENT,
+                   b: fd,
+                   c: event,
+                   d: data_len,
+               })
+        .map(|_| ())
+        .map_err(|e| Error::from_io_error(e, "failed to post fevent"))
+}


### PR DESCRIPTION
**Problem**: Redox doesn't support ICMP, it doesn't respond to ECHO requests, it doesn't have the `ping` utility.

**Solution**: Introduce the  `icmpd` daemon to handle incoming ICMP messages and provide file system abstraction of ICMP to other processes via the `icmp:` scheme.

 **Changes introduced by this pull request**:
- The `icmpd` daemon has been added.
- The daemon replies to incoming ICMP ECHO_REQUEST packets with valid ECHO_RESPOND packets.
- The daemon listens to `ip:1` and creates the `:icmp` scheme.
- The new scheme supports `echo/<ip-addr>` paths to interact with ICMP.
- Writing to an `echo/*` file sends an ICMP ECHO_REQUEST packet with the buffer argument as the packet's payload. `icmpd` sets the packet's id field to the value of the file handle used.
- An `echo/*` file produces an event on incoming ICMP ECHO_RESPONSE with id equal to the id assigned to the file handle.
- Reading from an `echo/*` file produces payload from the received packet.

**Drawbacks**: 
- Client processes has no access to the underlying network headers. For example, they can't check TTL of a response.

**State**: Redox replies to incoming ECHO requests and is able to send ECHO requests and process ECHO responses via the `ping` utility.

**TODOs**:
- Add support for `*_UNREACHABLE` messages to `icmpd`.
- Add `*_unreachable` methods to `icmpd` scheme.
- Add support for `icmpd` to `ipd`, `udpd` and `tcpd`.

**Other**: The qemu's default netwok settings don't support forwarding of ICMP packets, so additional configuration is required. Here's the [configuration I'm using](https://gist.github.com/batonius/886317dabca284cc4be2ea0c6cdcd5c8).