### PR TITLE
Use byteorder to improve readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
 name = "redox_netstack"
 version = "0.1.0"
 dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "netutils 0.1.0 (git+https://github.com/redox-os/netutils.git)",
  "redox_event 0.1.0 (git+https://github.com/redox-os/event.git)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/smolnetd/main.rs"
 netutils = { git = "https://github.com/redox-os/netutils.git" }
 redox_event = { git = "https://github.com/redox-os/event.git" }
 redox_syscall = { git = "https://github.com/redox-os/syscall.git" }
+byteorder = { version = "1.0", default-features = false }
 
 [dependencies.log]
 version = "0.3"

--- a/src/smolnetd/main.rs
+++ b/src/smolnetd/main.rs
@@ -6,6 +6,7 @@ extern crate log;
 extern crate netutils;
 extern crate smoltcp;
 extern crate syscall;
+extern crate byteorder;
 
 use std::cell::RefCell;
 use std::fs::File;


### PR DESCRIPTION
Use byteorder instead of using less readable bitmasks and shifts.