### PR TITLE
The netcfg scheme

### DIFF
--- a/src/lib/logger.rs
+++ b/src/lib/logger.rs
@@ -8,7 +8,7 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &LogRecord) {
-        println!("{}: {}", record.level(), record.args());
+        println!("{}: {}", record.target(), record.args());
     }
 }
 

--- a/src/smolnetd/scheme/icmp.rs
+++ b/src/smolnetd/scheme/icmp.rs
@@ -92,8 +92,10 @@ impl<'a, 'b> SchemeSocket for IcmpSocket<'a, 'b> {
                     tx_packets.push(IcmpPacketBuffer::new(vec![0; NetworkDevice::MTU]));
                 }
 
-                let socket = IcmpSocket::new(IcmpSocketBuffer::new(rx_packets),
-                                             IcmpSocketBuffer::new(tx_packets));
+                let socket = IcmpSocket::new(
+                    IcmpSocketBuffer::new(rx_packets),
+                    IcmpSocketBuffer::new(tx_packets),
+                );
                 let handle = socket_set.add(socket);
                 let mut icmp_socket = socket_set.get::<IcmpSocket>(handle);
                 let ident = ident_set

--- a/src/smolnetd/scheme/mod.rs
+++ b/src/smolnetd/scheme/mod.rs
@@ -183,8 +183,7 @@ impl Smolnetd {
                 }
                 iter_limit -= 1;
                 match iface.poll(&mut socket_set, timestamp) {
-                    Ok(_) => (),
-                    Err(smoltcp::Error::Unrecognized) => (),
+                    Ok(_) | Err(smoltcp::Error::Unrecognized) => (),
                     Err(e) => {
                         error!("poll error: {}", e);
                         break 0;

--- a/src/smolnetd/scheme/mod.rs
+++ b/src/smolnetd/scheme/mod.rs
@@ -71,7 +71,7 @@ impl Smolnetd {
             .expect("Can't parse the 'mac' cfg");
         let local_ip =
             IpAddress::from_str(getcfg("ip").unwrap().trim()).expect("Can't parse the 'ip' cfg.");
-        let protocol_addrs = [
+        let protocol_addrs = vec![
             IpCidr::new(local_ip, 24),
             IpCidr::new(IpAddress::v4(127, 0, 0, 1), 8),
         ];

--- a/src/smolnetd/scheme/mod.rs
+++ b/src/smolnetd/scheme/mod.rs
@@ -187,15 +187,15 @@ impl Smolnetd {
                     Err(smoltcp::Error::Unrecognized) => (),
                     Err(e) => {
                         error!("poll error: {}", e);
-                        break 0
+                        break 0;
                     }
                 }
                 match iface.poll_at(&socket_set, timestamp) {
                     Some(n) if n > timestamp => {
                         break ::std::cmp::min(::std::i64::MAX as u64, n - timestamp) as i64
-                    },
-                    Some(_) => {},
-                    None => break ::std::i64::MAX
+                    }
+                    Some(_) => {}
+                    None => break ::std::i64::MAX,
                 }
             }
         };

--- a/src/smolnetd/scheme/netcfg.rs
+++ b/src/smolnetd/scheme/netcfg.rs
@@ -1,0 +1,292 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::str;
+use std::rc::Rc;
+use std::iter::FromIterator;
+use syscall::data::Stat;
+use syscall::flag::{MODE_DIR, MODE_FILE};
+use syscall::{Error as SyscallError, Packet as SyscallPacket, Result as SyscallResult, SchemeMut};
+use syscall;
+
+use error::Result;
+use super::Interface;
+
+type CfgNodeRef = Rc<RefCell<CfgNode>>;
+
+trait CfgNode {
+    fn is_dir(&self) -> bool {
+        false
+    }
+
+    fn is_writable(&self) -> bool {
+        false
+    }
+
+    fn is_readable(&self) -> bool {
+        true
+    }
+
+    fn read(&self) -> Vec<u8> {
+        vec![]
+    }
+
+    fn write(&mut self, _buf: &[u8]) -> Option<usize> {
+        None
+    }
+
+    fn open(&self, _file: &str) -> Option<CfgNodeRef> {
+        None
+    }
+
+    fn close(&mut self) {}
+}
+
+struct RONode<F>
+where
+    F: Fn() -> Vec<u8>,
+{
+    read_fun: F,
+}
+
+impl<F> CfgNode for RONode<F>
+where
+    F: Fn() -> Vec<u8>,
+{
+    fn read(&self) -> Vec<u8> {
+        (self.read_fun)()
+    }
+}
+
+impl<F> RONode<F>
+where
+    F: 'static + Fn() -> Vec<u8>,
+{
+    fn new(read_fun: F) -> CfgNodeRef {
+        Rc::new(RefCell::new(RONode { read_fun }))
+    }
+}
+
+struct StaticDirNode {
+    child_nodes: BTreeMap<String, CfgNodeRef>,
+}
+
+impl CfgNode for StaticDirNode {
+    fn is_dir(&self) -> bool {
+        true
+    }
+
+    fn read(&self) -> Vec<u8> {
+        let mut files = vec![];
+        for child in self.child_nodes.keys() {
+            if !files.is_empty() {
+                files.push(b'\n');
+            }
+            files.extend(child.bytes());
+        }
+        files
+    }
+
+    fn open(&self, file: &str) -> Option<CfgNodeRef> {
+        self.child_nodes.get(file).map(|node| Rc::clone(node))
+    }
+}
+
+impl StaticDirNode {
+    pub fn new(child_nodes: BTreeMap<String, CfgNodeRef>) -> CfgNodeRef {
+        Rc::new(RefCell::new(StaticDirNode { child_nodes }))
+    }
+}
+
+struct RootNode {
+    route_node: CfgNodeRef,
+    iface_nodes: BTreeMap<String, CfgNodeRef>,
+}
+
+impl RootNode {
+    pub fn new(iface: Interface) -> RootNode {
+        let route_list_node = RONode::new(move || {
+            let default_route = if let Some(ip) = iface.borrow().ipv4_gateway() {
+                format!("default via {}\n", ip)
+            } else {
+                String::new()
+            };
+            Vec::from_iter(default_route.bytes())
+        });
+        let mut route_child_nodes = BTreeMap::new();
+        route_child_nodes.insert("list".to_owned(), route_list_node);
+        let route_node = StaticDirNode::new(route_child_nodes);
+        let iface_nodes = BTreeMap::new();
+        // let eth0_node: CfgNodeRef = Rc::new(RefCell::new(IfaceNode::new(iface)));
+        // iface_nodes.insert("eth0".to_owned(), eth0_node);
+        RootNode {
+            route_node,
+            iface_nodes,
+        }
+    }
+}
+
+impl CfgNode for RootNode {
+    fn is_dir(&self) -> bool {
+        true
+    }
+
+    fn open(&self, file: &str) -> Option<CfgNodeRef> {
+        match file {
+            "route" => Some(Rc::clone(&self.route_node)),
+            _ => self.iface_nodes.get(file).map(|node| Rc::clone(node)),
+        }
+    }
+
+    fn read(&self) -> Vec<u8> {
+        let mut files = vec![];
+        files.extend_from_slice(b"route");
+        for iface in self.iface_nodes.keys() {
+            files.push(b'\n');
+            files.extend(iface.bytes());
+        }
+        files
+    }
+}
+
+struct NetCfgFile {
+    cfg_node: CfgNodeRef,
+    data: Option<Vec<u8>>,
+    pos: usize,
+    uid: u32,
+}
+
+pub struct NetCfgScheme {
+    scheme_file: File,
+    next_fd: usize,
+    files: BTreeMap<usize, NetCfgFile>,
+    root_node: CfgNodeRef,
+}
+
+impl NetCfgScheme {
+    pub fn new(iface: Interface, scheme_file: File) -> NetCfgScheme {
+        NetCfgScheme {
+            scheme_file,
+            next_fd: 1,
+            files: BTreeMap::new(),
+            root_node: Rc::new(RefCell::new(RootNode::new(iface))),
+        }
+    }
+
+    pub fn on_scheme_event(&mut self) -> Result<Option<()>> {
+        loop {
+            let mut packet = SyscallPacket::default();
+            if self.scheme_file.read(&mut packet)? == 0 {
+                break;
+            }
+            self.handle(&mut packet);
+            self.scheme_file.write_all(&packet)?;
+        }
+        Ok(None)
+    }
+}
+
+impl SchemeMut for NetCfgScheme {
+    fn open(&mut self, url: &[u8], _flags: usize, uid: u32, _gid: u32) -> SyscallResult<usize> {
+        let path = str::from_utf8(url).or_else(|_| Err(SyscallError::new(syscall::EINVAL)))?;
+        let mut current_node = Rc::clone(&self.root_node);
+        for part in path.split('/') {
+            if part.is_empty() {
+                continue;
+            }
+            let next_node = current_node
+                .borrow_mut()
+                .open(part)
+                .ok_or_else(|| SyscallError::new(syscall::EINVAL))?;
+            current_node = next_node;
+        }
+        let fd = self.next_fd;
+        self.next_fd += 1;
+        self.files.insert(
+            fd,
+            NetCfgFile {
+                cfg_node: current_node,
+                uid,
+                pos: 0,
+                data: None,
+            },
+        );
+        Ok(fd)
+    }
+
+    fn close(&mut self, fd: usize) -> SyscallResult<usize> {
+        self.files
+            .get(&fd)
+            .ok_or_else(|| SyscallError::new(syscall::EBADF))?
+            .cfg_node
+            .borrow_mut()
+            .close();
+        self.files.remove(&fd);
+        Ok(0)
+    }
+
+    fn write(&mut self, fd: usize, buf: &[u8]) -> SyscallResult<usize> {
+        let file = self.files
+            .get(&fd)
+            .ok_or_else(|| SyscallError::new(syscall::EBADF))?;
+        if file.uid != 0 {
+            return Err(SyscallError::new(syscall::EACCES));
+        }
+        file.cfg_node
+            .borrow_mut()
+            .write(buf)
+            .ok_or_else(|| SyscallError::new(syscall::EINVAL))
+    }
+
+    fn read(&mut self, fd: usize, buf: &mut [u8]) -> SyscallResult<usize> {
+        let file = self.files
+            .get_mut(&fd)
+            .ok_or_else(|| SyscallError::new(syscall::EBADF))?;
+        if file.data.is_none() {
+            file.data = Some(file.cfg_node.borrow().read())
+        }
+        if let Some(ref data) = file.data {
+            let mut i = 0;
+            while i < buf.len() && file.pos < data.len() {
+                buf[i] = data[file.pos];
+                i += 1;
+                file.pos += 1;
+            }
+            return Ok(i);
+        }
+        Err(SyscallError::new(syscall::EINVAL))
+    }
+
+    fn fstat(&mut self, fd: usize, stat: &mut Stat) -> SyscallResult<usize> {
+        let file = self.files
+            .get_mut(&fd)
+            .ok_or_else(|| SyscallError::new(syscall::EBADF))?;
+        let cfg_node = file.cfg_node.borrow();
+
+        stat.st_mode = if cfg_node.is_dir() {
+            MODE_DIR
+        } else {
+            MODE_FILE
+        };
+        if cfg_node.is_writable() {
+            stat.st_mode |= 0o222;
+        }
+        if cfg_node.is_readable() {
+            stat.st_mode |= 0o444;
+        }
+        stat.st_uid = 0;
+        stat.st_gid = 0;
+
+        if file.data.is_none() {
+            file.data = Some(file.cfg_node.borrow().read())
+        }
+        if let Some(ref data) = file.data {
+            stat.st_size = data.len() as u64;
+        } else {
+            stat.st_size = 0;
+        }
+
+        Ok(0)
+    }
+}

--- a/src/smolnetd/scheme/netcfg.rs
+++ b/src/smolnetd/scheme/netcfg.rs
@@ -3,8 +3,10 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::str;
+use std::str::FromStr;
 use std::rc::Rc;
 use std::iter::FromIterator;
+use smoltcp::wire::{EthernetAddress, Ipv4Address};
 use syscall::data::Stat;
 use syscall::flag::{MODE_DIR, MODE_FILE};
 use syscall::{Error as SyscallError, Packet as SyscallPacket, Result as SyscallResult, SchemeMut};
@@ -12,6 +14,8 @@ use syscall;
 
 use error::Result;
 use super::Interface;
+
+const WRITE_BUFFER_MAX_SIZE: usize = 0xffff;
 
 type CfgNodeRef = Rc<RefCell<CfgNode>>;
 
@@ -32,15 +36,13 @@ trait CfgNode {
         vec![]
     }
 
-    fn write(&mut self, _buf: &[u8]) -> Option<usize> {
-        None
+    fn write(&self, _buf: &[u8]) -> SyscallResult<usize> {
+        Ok(0)
     }
 
     fn open(&self, _file: &str) -> Option<CfgNodeRef> {
         None
     }
-
-    fn close(&mut self) {}
 }
 
 struct RONode<F>
@@ -65,6 +67,75 @@ where
 {
     fn new(read_fun: F) -> CfgNodeRef {
         Rc::new(RefCell::new(RONode { read_fun }))
+    }
+}
+
+struct WONode<F>
+where
+    F: Fn(&[u8]) -> SyscallResult<usize>,
+{
+    write_fun: F,
+}
+
+impl<F> CfgNode for WONode<F>
+where
+    F: Fn(&[u8]) -> SyscallResult<usize>,
+{
+    fn write(&self, buf: &[u8]) -> SyscallResult<usize> {
+        (self.write_fun)(buf)
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
+impl<F> WONode<F>
+where
+    F: 'static + Fn(&[u8]) -> SyscallResult<usize>,
+{
+    fn new(write_fun: F) -> CfgNodeRef {
+        Rc::new(RefCell::new(WONode { write_fun }))
+    }
+}
+
+struct RWNode<F, G>
+where
+    F: Fn() -> Vec<u8>,
+    G: Fn(&[u8]) -> SyscallResult<usize>,
+{
+    read_fun: F,
+    write_fun: G,
+}
+
+impl<F, G> CfgNode for RWNode<F, G>
+where
+    F: Fn() -> Vec<u8>,
+    G: Fn(&[u8]) -> SyscallResult<usize>,
+{
+    fn read(&self) -> Vec<u8> {
+        (self.read_fun)()
+    }
+
+    fn write(&self, buf: &[u8]) -> SyscallResult<usize> {
+        (self.write_fun)(buf)
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
+impl<F, G> RWNode<F, G>
+where
+    F: 'static + Fn() -> Vec<u8>,
+    G: 'static + Fn(&[u8]) -> SyscallResult<usize>,
+{
+    fn new(read_fun: F, write_fun: G) -> CfgNodeRef {
+        Rc::new(RefCell::new(RWNode {
+            read_fun,
+            write_fun,
+        }))
     }
 }
 
@@ -99,60 +170,97 @@ impl StaticDirNode {
     }
 }
 
-struct RootNode {
-    route_node: CfgNodeRef,
-    iface_nodes: BTreeMap<String, CfgNodeRef>,
+fn parse_default_gw(buf: &[u8]) -> SyscallResult<Ipv4Address> {
+    let value = str::from_utf8(buf).or_else(|_| Err(SyscallError::new(syscall::EINVAL)))?;
+    let mut routes = value.lines();
+    if let Some(route) = routes.next() {
+        if !routes.next().is_none() {
+            return Err(SyscallError::new(syscall::EINVAL));
+        }
+        let mut words = route.split_whitespace();
+        if let Some("default") = words.next() {
+            if let Some("via") = words.next() {
+                if let Some(ip) = words.next() {
+                    return Ipv4Address::from_str(ip)
+                        .map_err(|_| SyscallError::new(syscall::EINVAL));
+                }
+            }
+        }
+    }
+    Err(SyscallError::new(syscall::EINVAL))
 }
 
-impl RootNode {
-    pub fn new(iface: Interface) -> RootNode {
-        let route_list_node = RONode::new(move || {
-            let default_route = if let Some(ip) = iface.borrow().ipv4_gateway() {
-                format!("default via {}\n", ip)
-            } else {
-                String::new()
-            };
-            Vec::from_iter(default_route.bytes())
-        });
-        let mut route_child_nodes = BTreeMap::new();
-        route_child_nodes.insert("list".to_owned(), route_list_node);
-        let route_node = StaticDirNode::new(route_child_nodes);
-        let iface_nodes = BTreeMap::new();
-        // let eth0_node: CfgNodeRef = Rc::new(RefCell::new(IfaceNode::new(iface)));
-        // iface_nodes.insert("eth0".to_owned(), eth0_node);
-        RootNode {
-            route_node,
-            iface_nodes,
+fn mk_route_node(iface: &Interface) -> CfgNodeRef {
+    let iface_ = Rc::clone(iface);
+    let route_list_node = RONode::new(move || {
+        let default_route = if let Some(ip) = iface_.borrow().ipv4_gateway() {
+            format!("default via {}\n", ip)
+        } else {
+            String::new()
+        };
+        Vec::from_iter(default_route.bytes())
+    });
+    let iface_ = Rc::clone(iface);
+    let route_add_node = WONode::new(move |buf: &[u8]| -> SyscallResult<usize> {
+        let default_gw = parse_default_gw(buf)?;
+        iface_.borrow_mut().set_ipv4_gateway(Some(default_gw));
+        Ok(0)
+    });
+    let iface_ = Rc::clone(iface);
+    let route_rm_node = WONode::new(move |buf: &[u8]| -> SyscallResult<usize> {
+        let default_gw = parse_default_gw(buf)?;
+        let mut iface = iface_.borrow_mut();
+        if iface.ipv4_gateway() != Some(default_gw) {
+            return Err(SyscallError::new(syscall::EINVAL));
         }
-    }
+        iface.set_ipv4_gateway(None);
+        Ok(0)
+    });
+    let mut route_child_nodes = BTreeMap::new();
+    route_child_nodes.insert("list".to_owned(), route_list_node);
+    route_child_nodes.insert("add".to_owned(), route_add_node);
+    route_child_nodes.insert("rm".to_owned(), route_rm_node);
+    StaticDirNode::new(route_child_nodes)
 }
 
-impl CfgNode for RootNode {
-    fn is_dir(&self) -> bool {
-        true
-    }
+fn mk_iface_node(iface: &Interface) -> CfgNodeRef {
+    let iface_ = Rc::clone(iface);
+    let iface__ = Rc::clone(iface);
+    let iface_mac_node = RWNode::new(
+        move || Vec::from_iter(format!("{}\n", iface_.borrow().ethernet_addr()).bytes()),
+        move |buf: &[u8]| -> SyscallResult<usize> {
+            let value = str::from_utf8(buf).or_else(|_| Err(SyscallError::new(syscall::EINVAL)))?;
+            let mac =
+                EthernetAddress::from_str(value).map_err(|_| SyscallError::new(syscall::EINVAL))?;
+            if !mac.is_unicast() {
+                return Err(SyscallError::new(syscall::EINVAL));
+            }
+            iface__.borrow_mut().set_ethernet_addr(mac);
+            Ok(0)
+        },
+    );
+    let mut iface_child_nodes = BTreeMap::new();
+    iface_child_nodes.insert("mac".to_owned(), iface_mac_node);
+    StaticDirNode::new(iface_child_nodes)
+}
 
-    fn open(&self, file: &str) -> Option<CfgNodeRef> {
-        match file {
-            "route" => Some(Rc::clone(&self.route_node)),
-            _ => self.iface_nodes.get(file).map(|node| Rc::clone(node)),
-        }
-    }
+fn mk_root_node(iface: Interface) -> CfgNodeRef {
+    let route_node = mk_route_node(&iface);
+    let mut ifaces_nodes = BTreeMap::new();
 
-    fn read(&self) -> Vec<u8> {
-        let mut files = vec![];
-        files.extend_from_slice(b"route");
-        for iface in self.iface_nodes.keys() {
-            files.push(b'\n');
-            files.extend(iface.bytes());
-        }
-        files
-    }
+    ifaces_nodes.insert("eth0".to_owned(), mk_iface_node(&iface));
+    let ifaces_node = StaticDirNode::new(ifaces_nodes);
+
+    let mut root_child_nodes = BTreeMap::new();
+    root_child_nodes.insert("route".to_owned(), route_node);
+    root_child_nodes.insert("ifaces".to_owned(), ifaces_node);
+    StaticDirNode::new(root_child_nodes)
 }
 
 struct NetCfgFile {
     cfg_node: CfgNodeRef,
-    data: Option<Vec<u8>>,
+    read_buf: Vec<u8>,
+    write_buf: Vec<u8>,
     pos: usize,
     uid: u32,
 }
@@ -170,7 +278,7 @@ impl NetCfgScheme {
             scheme_file,
             next_fd: 1,
             files: BTreeMap::new(),
-            root_node: Rc::new(RefCell::new(RootNode::new(iface))),
+            root_node: mk_root_node(iface),
         }
     }
 
@@ -201,6 +309,7 @@ impl SchemeMut for NetCfgScheme {
                 .ok_or_else(|| SyscallError::new(syscall::EINVAL))?;
             current_node = next_node;
         }
+        let read_buf = current_node.borrow().read();
         let fd = self.next_fd;
         self.next_fd += 1;
         self.files.insert(
@@ -209,53 +318,48 @@ impl SchemeMut for NetCfgScheme {
                 cfg_node: current_node,
                 uid,
                 pos: 0,
-                data: None,
+                read_buf,
+                write_buf: vec![],
             },
         );
         Ok(fd)
     }
 
     fn close(&mut self, fd: usize) -> SyscallResult<usize> {
-        self.files
-            .get(&fd)
-            .ok_or_else(|| SyscallError::new(syscall::EBADF))?
-            .cfg_node
-            .borrow_mut()
-            .close();
-        self.files.remove(&fd);
-        Ok(0)
+        let file = self.files
+            .get_mut(&fd)
+            .ok_or_else(|| SyscallError::new(syscall::EBADF))?;
+        file.cfg_node.borrow().write(&file.write_buf)
     }
 
     fn write(&mut self, fd: usize, buf: &[u8]) -> SyscallResult<usize> {
         let file = self.files
-            .get(&fd)
+            .get_mut(&fd)
             .ok_or_else(|| SyscallError::new(syscall::EBADF))?;
+
         if file.uid != 0 {
             return Err(SyscallError::new(syscall::EACCES));
         }
-        file.cfg_node
-            .borrow_mut()
-            .write(buf)
-            .ok_or_else(|| SyscallError::new(syscall::EINVAL))
+
+        if (WRITE_BUFFER_MAX_SIZE - file.write_buf.len()) < buf.len() {
+            return Err(SyscallError::new(syscall::EMSGSIZE));
+        }
+        file.write_buf.extend_from_slice(buf);
+        Ok(buf.len())
     }
 
     fn read(&mut self, fd: usize, buf: &mut [u8]) -> SyscallResult<usize> {
         let file = self.files
             .get_mut(&fd)
             .ok_or_else(|| SyscallError::new(syscall::EBADF))?;
-        if file.data.is_none() {
-            file.data = Some(file.cfg_node.borrow().read())
+
+        let mut i = 0;
+        while i < buf.len() && file.pos < file.read_buf.len() {
+            buf[i] = file.read_buf[file.pos];
+            i += 1;
+            file.pos += 1;
         }
-        if let Some(ref data) = file.data {
-            let mut i = 0;
-            while i < buf.len() && file.pos < data.len() {
-                buf[i] = data[file.pos];
-                i += 1;
-                file.pos += 1;
-            }
-            return Ok(i);
-        }
-        Err(SyscallError::new(syscall::EINVAL))
+        Ok(i)
     }
 
     fn fstat(&mut self, fd: usize, stat: &mut Stat) -> SyscallResult<usize> {
@@ -277,15 +381,7 @@ impl SchemeMut for NetCfgScheme {
         }
         stat.st_uid = 0;
         stat.st_gid = 0;
-
-        if file.data.is_none() {
-            file.data = Some(file.cfg_node.borrow().read())
-        }
-        if let Some(ref data) = file.data {
-            stat.st_size = data.len() as u64;
-        } else {
-            stat.st_size = 0;
-        }
+        stat.st_size = file.read_buf.len() as u64;
 
         Ok(0)
     }

--- a/src/smolnetd/scheme/netcfg/nodes.rs
+++ b/src/smolnetd/scheme/netcfg/nodes.rs
@@ -1,0 +1,199 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::collections::BTreeMap;
+use syscall::Result as SyscallResult;
+
+pub type CfgNodeRef = Rc<RefCell<CfgNode>>;
+
+pub trait CfgNode {
+    fn is_dir(&self) -> bool {
+        false
+    }
+
+    fn is_writable(&self) -> bool {
+        false
+    }
+
+    fn is_readable(&self) -> bool {
+        true
+    }
+
+    fn read(&self) -> String {
+        String::new()
+    }
+
+    fn write(&self, _buf: &str) -> SyscallResult<usize> {
+        Ok(0)
+    }
+
+    fn open(&self, _file: &str) -> Option<CfgNodeRef> {
+        None
+    }
+}
+
+pub struct RONode<F>
+where
+    F: Fn() -> String,
+{
+    read_fun: F,
+}
+
+impl<F> CfgNode for RONode<F>
+where
+    F: Fn() -> String,
+{
+    fn read(&self) -> String {
+        (self.read_fun)()
+    }
+}
+
+impl<F> RONode<F>
+where
+    F: 'static + Fn() -> String,
+{
+    pub fn new_ref(read_fun: F) -> CfgNodeRef {
+        Rc::new(RefCell::new(RONode { read_fun }))
+    }
+}
+
+pub struct WONode<F>
+where
+    F: Fn(&str) -> SyscallResult<usize>,
+{
+    write_fun: F,
+}
+
+impl<F> CfgNode for WONode<F>
+where
+    F: Fn(&str) -> SyscallResult<usize>,
+{
+    fn write(&self, buf: &str) -> SyscallResult<usize> {
+        (self.write_fun)(buf)
+    }
+
+    fn is_readable(&self) -> bool {
+        false
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
+impl<F> WONode<F>
+where
+    F: 'static + Fn(&str) -> SyscallResult<usize>,
+{
+    pub fn new_ref(write_fun: F) -> CfgNodeRef {
+        Rc::new(RefCell::new(WONode { write_fun }))
+    }
+}
+
+pub struct RWNode<F, G>
+where
+    F: Fn() -> String,
+    G: Fn(&str) -> SyscallResult<usize>,
+{
+    read_fun: F,
+    write_fun: G,
+}
+
+impl<F, G> CfgNode for RWNode<F, G>
+where
+    F: Fn() -> String,
+    G: Fn(&str) -> SyscallResult<usize>,
+{
+    fn read(&self) -> String {
+        (self.read_fun)()
+    }
+
+    fn write(&self, buf: &str) -> SyscallResult<usize> {
+        (self.write_fun)(buf)
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
+impl<F, G> RWNode<F, G>
+where
+    F: 'static + Fn() -> String,
+    G: 'static + Fn(&str) -> SyscallResult<usize>,
+{
+    pub fn new_ref(read_fun: F, write_fun: G) -> CfgNodeRef {
+        Rc::new(RefCell::new(RWNode {
+            read_fun,
+            write_fun,
+        }))
+    }
+}
+
+pub struct StaticDirNode {
+    child_nodes: BTreeMap<String, CfgNodeRef>,
+}
+
+impl CfgNode for StaticDirNode {
+    fn is_dir(&self) -> bool {
+        true
+    }
+
+    fn read(&self) -> String {
+        let mut files = String::new();
+        for child in self.child_nodes.keys() {
+            if !files.is_empty() {
+                files.push('\n');
+            }
+            files += child;
+        }
+        files
+    }
+
+    fn open(&self, file: &str) -> Option<CfgNodeRef> {
+        self.child_nodes.get(file).map(|node| Rc::clone(node))
+    }
+}
+
+impl StaticDirNode {
+    pub fn new_ref(child_nodes: BTreeMap<String, CfgNodeRef>) -> CfgNodeRef {
+        Rc::new(RefCell::new(StaticDirNode { child_nodes }))
+    }
+}
+
+macro_rules! cfg_node {
+    (val $e:expr) => {
+        $e
+    };
+    (ro [ $($c:ident),* ] || $b:block ) => {
+        {
+            $(let $c = $c.clone();)*
+            RONode::new_ref(move|| $b)
+        }
+    };
+    (wo [ $($c:ident),* ] |$i:ident| $b:block ) => {
+        {
+            $(let $c = $c.clone();)*
+            WONode::new_ref(move |$i: &str| $b)
+        }
+    };
+    (rw [ $($c:ident),* ] || $rb:block |$i:ident| $wb:block ) => {
+        {
+            let read_fun = {
+                $(#[allow(unused_variables)] let $c = $c.clone();)*
+                move || $rb
+            };
+            let write_fun = {
+                $(#[allow(unused_variables)] let $c = $c.clone();)*
+                move |$i: &str| $wb
+            };
+            RWNode::new_ref(read_fun, write_fun)
+        }
+    };
+    ($($e:expr => { $($t:tt)* }),* $(,)*) => {
+        {
+            let mut children = BTreeMap::new();
+            $(children.insert($e.into(), cfg_node!($($t)*));)*
+            StaticDirNode::new_ref(children)
+        }
+    };
+}

--- a/src/smolnetd/scheme/netcfg/notifier.rs
+++ b/src/smolnetd/scheme/netcfg/notifier.rs
@@ -1,0 +1,62 @@
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::collections::btree_map::Entry;
+
+pub struct Notifier {
+    listeners: BTreeMap<String, BTreeSet<usize>>,
+    notified: BTreeSet<usize>,
+}
+
+pub type NotifierRef = Rc<RefCell<Notifier>>;
+
+impl Notifier {
+    pub fn new_ref() -> NotifierRef {
+        Rc::new(RefCell::new(Notifier {
+            listeners: BTreeMap::new(),
+            notified: BTreeSet::new(),
+        }))
+    }
+
+    pub fn subscribe(&mut self, path: &str, fd: usize) {
+        trace!("Sub fd {} to {}", fd, path);
+        match self.listeners.entry(path.to_owned()) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().insert(fd);
+            }
+            Entry::Vacant(e) => {
+                let mut fds = BTreeSet::new();
+                fds.insert(fd);
+                e.insert(fds);
+            }
+        }
+    }
+
+    pub fn unsubscribe(&mut self, path: &str, fd: usize) {
+        let empty = if let Some(fds) = self.listeners.get_mut(path) {
+            if fds.remove(&fd) {
+                trace!("Unsub fd {} from {}", fd, path);
+            }
+            fds.is_empty()
+        } else {
+            false
+        };
+        if empty {
+            self.listeners.remove(path);
+        }
+    }
+
+    pub fn schedule_notify(&mut self, path: &str) {
+        trace!("Notifying {}", path);
+        if let Some(fds) = self.listeners.get(path) {
+            self.notified.extend(fds);
+        }
+    }
+
+    pub fn get_notified_fds(&mut self) -> BTreeSet<usize> {
+        use std::mem::swap;
+        let mut notified = BTreeSet::new();
+        swap(&mut self.notified, &mut notified);
+        notified
+    }
+}

--- a/src/smolnetd/scheme/socket.rs
+++ b/src/smolnetd/scheme/socket.rs
@@ -84,8 +84,8 @@ where
 {
     pub fn socket_handle(&self) -> SocketHandle {
         match *self {
-            SchemeFile::Socket(SocketFile { socket_handle, .. }) |
-            SchemeFile::Setting(SettingFile { socket_handle, .. }) => socket_handle,
+            SchemeFile::Socket(SocketFile { socket_handle, .. })
+            | SchemeFile::Setting(SettingFile { socket_handle, .. }) => socket_handle,
         }
     }
 }
@@ -580,9 +580,10 @@ where
     }
 
     fn dup(&mut self, fd: usize, buf: &[u8]) -> SyscallResult<usize> {
-        if let Some((flags, uid, gid)) = self.nulls.get(&fd).map(|null| {
-            (null.flags, null.uid, null.gid)
-        }) {
+        if let Some((flags, uid, gid)) = self.nulls
+            .get(&fd)
+            .map(|null| (null.flags, null.uid, null.gid))
+        {
             return self.open(buf, flags, uid, gid);
         }
 

--- a/src/smolnetd/scheme/tcp.rs
+++ b/src/smolnetd/scheme/tcp.rs
@@ -65,8 +65,8 @@ impl<'a> SchemeSocket for TcpSocket<'a> {
             return Err(SyscallError::new(syscall::EACCES));
         }
 
-        let rx_packets = vec![0; 65_535];
-        let tx_packets = vec![0; 65_535];
+        let rx_packets = vec![0; 0xffff];
+        let tx_packets = vec![0; 0xffff];
         let rx_buffer = TcpSocketBuffer::new(rx_packets);
         let tx_buffer = TcpSocketBuffer::new(tx_packets);
         let socket = TcpSocket::new(rx_buffer, tx_buffer);
@@ -164,8 +164,8 @@ impl<'a> SchemeSocket for TcpSocket<'a> {
                 trace!("TCP creating new listening socket");
                 let new_handle = SchemeFile::Socket(tcp_handle.clone_with_data(()));
 
-                let rx_packets = vec![0; 65_535];
-                let tx_packets = vec![0; 65_535];
+                let rx_packets = vec![0; 0xffff];
+                let tx_packets = vec![0; 0xffff];
                 let rx_buffer = TcpSocketBuffer::new(rx_packets);
                 let tx_buffer = TcpSocketBuffer::new(tx_packets);
                 let socket = TcpSocket::new(rx_buffer, tx_buffer);


### PR DESCRIPTION
The PR implements the `netcfg` scheme as described in #7.

**Notes:**
- Right now configuration nodes hardcoded in https://github.com/batonius/netstack/blob/netcfg/src/smolnetd/scheme/netcfg/mod.rs#L45 are `resolv/nameserver`, `route/{list, add, rm}`, `iface/eth0/{mac, addr/{list, add, rm}}`, these should be enough for DHCP. There's nothing preventing the dynamic creation of nodes.
- The schema implements directories, so it can be traversed as a regular file system.
- Readable nodes reflected the state of affairs at the time of `open` call, not the first `read`.
- Writable nodes 'commit' changes on `close`, not `write`.
- Nodes can notify about changes using `fevent`, to read the new value the file should be reopened.
- Right now the only route type supported is the default route which looks like `default via 192.168.1.1`.
- MAC and IP addresses of the interface are updated in `smoltcp`, the changes take effect immediately.
- `dnsd` has been updated to watch `resolv/nameserver` and switch nameservers on the fly.

Closes #7.