### PR TITLE
Switch to an edge-triggered event system

### DIFF
--- a/src/smolnetd/scheme/udp.rs
+++ b/src/smolnetd/scheme/udp.rs
@@ -117,7 +117,7 @@ impl<'a, 'b> SchemeSocket for UdpSocket<'a, 'b> {
             self.send_slice(buf, file.data).expect("Can't send slice");
             Ok(buf.len())
         } else if file.flags & syscall::O_NONBLOCK == syscall::O_NONBLOCK {
-            Ok(0)
+            Err(SyscallError::new(syscall::EAGAIN))
         } else {
             Err(SyscallError::new(syscall::EWOULDBLOCK))
         }
@@ -132,7 +132,7 @@ impl<'a, 'b> SchemeSocket for UdpSocket<'a, 'b> {
             let (length, _) = self.recv_slice(buf).expect("Can't receive slice");
             Ok(length)
         } else if file.flags & syscall::O_NONBLOCK == syscall::O_NONBLOCK {
-            Ok(0)
+            Err(SyscallError::new(syscall::EAGAIN))
         } else {
             Err(SyscallError::new(syscall::EWOULDBLOCK))
         }


### PR DESCRIPTION
 - Only send events once.
 - Resend events when new file is registered.
 - Return EAGAIN when a read would be blocking.
 - Return EAGAIN when an accept would be blocking (<- new! accepts can now be nonblocking!)

This matches the behavior of other systems more closely and allows me to basically almost completely revert all my work on tokio. It feels kind of sad but it's for the best.